### PR TITLE
fix: avoid .cjs extension for parcel-bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/3846masa/bmp/issues"
   },
-  "main": "lib/convert.cjs",
+  "main": "lib/convert.js",
   "module": "lib/covert.mjs",
   "files": [
     "lib",
@@ -43,7 +43,7 @@
   "esnext": "src/convert.mjs",
   "size-limit": [
     {
-      "path": "lib/convert.cjs",
+      "path": "lib/convert.js",
       "limit": "500 B"
     },
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ const config = [
   {
     input: './src/convert.mjs',
     output: {
-      file: './lib/convert.cjs',
+      file: './lib/convert.js',
       format: 'commonjs',
     },
     plugins: [terser()],


### PR DESCRIPTION
* parcel-bundler v1 does not support .cjs extension file.